### PR TITLE
docs: add LICENSING.md pointer to canonical IP/licensing strategy

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,8 @@
+# Licensing
+
+This repository is licensed under the **BSD 3-Clause License** (see [LICENSE](LICENSE)). It belongs to the **public** tier of the Lux three-tier IP strategy: anyone may use, fork, or redistribute it, including for commercial purposes, subject to the BSD 3-Clause License terms.
+
+For the canonical Lux IP and licensing strategy, see:
+<https://github.com/luxfi/.github/blob/main/profile/README.md>
+
+For commercial inquiries that go beyond the public tier (e.g. private moat acceleration kernels, Eco-tier patent-protected primitives outside Authorized Networks), contact `licensing@lux.network`.


### PR DESCRIPTION
Adds a top-level LICENSING.md that names this repository's binding license tier and points to the canonical Lux IP/licensing strategy at luxfi/.github. Strategy is locked: no Eco -> BSD-3 flips planned; Eco repos are the catalog for commercial licensing.