### PR TITLE
chore: bump Go toolchain to 1.26.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version: 1.26.3
         cache: false
 
     - name: Run linters
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: false
 
       - name: Build
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: false
 
       - name: Install cross toolchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 


### PR DESCRIPTION
Pin Go version to 1.26.3 across go.mod, CI workflows, and Dockerfiles for canonical alignment with the rest of the luxfi/* stack.